### PR TITLE
chore: skip integration tests in restricted environments

### DIFF
--- a/src/tests/integration/infrastructure/test_service_integration.py
+++ b/src/tests/integration/infrastructure/test_service_integration.py
@@ -14,6 +14,9 @@ from src.domain.value_objects.language import Language, LanguagePair
 from src.infrastructure.services.ocr_service import TesseractOCRService
 from src.infrastructure.services.translation_service import GoogleTranslationService
 from src.infrastructure.services.tts_service import PyttsxTTSService
+from src.tests.test_utils import requires_tesseract, skip_on_ci
+
+pytestmark = pytest.mark.integration
 
 
 class TestServiceIntegration:
@@ -29,6 +32,8 @@ class TestServiceIntegration:
             self.ocr_service, self.translation_service, self.tts_service
         )
 
+    @skip_on_ci
+    @requires_tesseract
     def test_service_availability_validation(self):
         """Test service availability validation."""
         result = self.workflow_service.validate_services()
@@ -43,6 +48,8 @@ class TestServiceIntegration:
         assert isinstance(result["translation"], bool)
         assert isinstance(result["tts"], bool)
 
+    @skip_on_ci
+    @requires_tesseract
     @pytest.mark.asyncio
     async def test_workflow_service_error_handling(self):
         """Test workflow service handles service errors gracefully."""
@@ -59,6 +66,8 @@ class TestServiceIntegration:
             # Should handle error gracefully
             assert result is None
 
+    @skip_on_ci
+    @requires_tesseract
     @pytest.mark.asyncio
     async def test_service_chain_integration(self):
         """Test full service chain integration with mocked external dependencies."""
@@ -92,6 +101,8 @@ class TestServiceIntegration:
                         # Verify TTS was called
                         self.tts_service.speak.assert_called_once()
 
+    @skip_on_ci
+    @requires_tesseract
     @pytest.mark.asyncio
     async def test_service_resilience_partial_failures(self):
         """Test service resilience when some services fail."""
@@ -117,6 +128,8 @@ class TestServiceIntegration:
                     assert result.original.content == "Test text"
                     assert result.translated.content == "Тестовый текст"
 
+    @skip_on_ci
+    @requires_tesseract
     def test_service_configuration_loading(self):
         """Test that services load configuration correctly."""
         # Test OCR service
@@ -129,6 +142,8 @@ class TestServiceIntegration:
         assert hasattr(self.tts_service, "_engine")
         assert hasattr(self.tts_service, "_lock")
 
+    @skip_on_ci
+    @requires_tesseract
     @pytest.mark.asyncio
     async def test_service_thread_safety(self):
         """Test that services handle concurrent access safely."""

--- a/src/tests/integration/test_core_workflow.py
+++ b/src/tests/integration/test_core_workflow.py
@@ -13,6 +13,8 @@ import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
 try:
     from PIL import Image
 
@@ -33,8 +35,12 @@ from src.models.screenshot_data import ScreenshotData
 from src.services.cache_service import TranslationCache
 from src.services.config_manager import ConfigManager
 from src.services.container import DIContainer, setup_default_services
+from src.tests.test_utils import skip_on_ci
+
+pytestmark = pytest.mark.integration
 
 
+@skip_on_ci
 @unittest.skipUnless(PIL_AVAILABLE, "PIL not available")
 class TestCoreWorkflowIntegration(unittest.TestCase):
     """Integration tests for core workflow components"""
@@ -424,6 +430,7 @@ class TestCoreWorkflowIntegration(unittest.TestCase):
         )
 
 
+@skip_on_ci
 @unittest.skipUnless(PIL_AVAILABLE, "PIL not available")
 class TestWorkflowPerformance(unittest.TestCase):
     """Performance tests for workflow components"""

--- a/src/tests/integration/test_main_scenarios.py
+++ b/src/tests/integration/test_main_scenarios.py
@@ -10,15 +10,21 @@ import unittest
 from typing import Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
 from src.models.config import AppConfig, HotkeyConfig, LanguageConfig, TTSConfig
 from src.services.container import DIContainer
 
 # Импорт основных компонентов
 from src.services.task_queue import TaskPriority, TaskQueue
 from src.services.translation_cache import TranslationCache
+from src.tests.test_utils import skip_on_ci
 from src.utils.logger import logger
 
+pytestmark = pytest.mark.integration
 
+
+@skip_on_ci
 class TestMainScenarios(unittest.TestCase):
     """Интеграционные тесты основных сценариев"""
 
@@ -382,6 +388,7 @@ class TestMainScenarios(unittest.TestCase):
         self.assertEqual(stats["total_tasks"], num_tasks)
 
 
+@skip_on_ci
 class TestPerformanceScenarios(unittest.TestCase):
     """Тесты производительности основных сценариев"""
 

--- a/src/tests/integration/test_new_features_integration.py
+++ b/src/tests/integration/test_new_features_integration.py
@@ -15,20 +15,21 @@ from pathlib import Path
 
 from PIL import Image
 
+import pytest
+
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
-from src.tests.test_utils import has_display  # noqa: E402
+from src.tests.test_utils import skip_on_ci, skip_without_display  # noqa: E402
+
+pytestmark = pytest.mark.integration
 
 
+@skip_on_ci
+@skip_without_display
 def test_progress_and_notifications():
     """Test progress indicators and notifications integration"""
     print("Testing progress indicators and notifications...")
-
-    # Skip if no display available
-    if not has_display:
-        print("[SKIP] Progress and notifications test skipped - no display available")
-        return True
 
     try:
         import tkinter as tk
@@ -69,6 +70,7 @@ def test_progress_and_notifications():
         return False
 
 
+@skip_on_ci
 def test_batch_processing():
     """Test batch processing integration"""
     print("Testing batch processing...")
@@ -162,6 +164,7 @@ def test_batch_processing():
         return False
 
 
+@skip_on_ci
 def test_export_functionality():
     """Test export functionality"""
     print("Testing export functionality...")
@@ -237,6 +240,7 @@ def test_export_functionality():
         return False
 
 
+@skip_on_ci
 def test_performance_monitoring():
     """Test performance monitoring"""
     print("Testing performance monitoring...")
@@ -324,6 +328,7 @@ def test_performance_monitoring():
         return False
 
 
+@skip_on_ci
 def test_enhanced_ocr():
     """Test enhanced OCR with confidence thresholds"""
     print("Testing enhanced OCR...")
@@ -375,14 +380,11 @@ def test_enhanced_ocr():
         return False
 
 
+@skip_on_ci
+@skip_without_display
 def test_drag_drop_simulation():
     """Test drag and drop simulation"""
     print("Testing drag and drop simulation...")
-
-    # Skip if no display available
-    if not has_display:
-        print("[SKIP] Drag and drop test skipped - no display available")
-        return True
 
     try:
         import tkinter as tk
@@ -479,14 +481,11 @@ def test_drag_drop_simulation():
         return False
 
 
+@skip_on_ci
+@skip_without_display
 def test_full_workflow():
     """Test complete workflow with new features"""
     print("Testing complete workflow...")
-
-    # Skip if no display available
-    if not has_display:
-        print("[SKIP] Complete workflow test skipped - no display available")
-        return True
 
     try:
         import tkinter as tk

--- a/src/tests/integration/test_system_integration.py
+++ b/src/tests/integration/test_system_integration.py
@@ -9,10 +9,18 @@ import sys
 import threading
 import time
 
+import pytest
+
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
+from src.tests.test_utils import skip_on_ci, skip_without_display
 
+pytestmark = pytest.mark.integration
+
+
+@skip_on_ci
+@skip_without_display
 def test_services_integration():
     """Test all services working together."""
     print("Testing services integration...")
@@ -59,6 +67,7 @@ def test_services_integration():
         return False
 
 
+@skip_on_ci
 def test_plugin_system():
     """Test plugin system integration."""
     print("Testing plugin system...")
@@ -91,6 +100,8 @@ def test_plugin_system():
         return False
 
 
+@skip_on_ci
+@skip_without_display
 def test_ui_components():
     """Test UI components."""
     print("Testing UI components...")
@@ -117,6 +128,7 @@ def test_ui_components():
         return False
 
 
+@skip_on_ci
 def test_api_system():
     """Test API system configuration."""
     print("Testing API system...")
@@ -142,6 +154,7 @@ def test_api_system():
         return False
 
 
+@skip_on_ci
 def test_workflow_simulation():
     """Test complete workflow simulation."""
     print("Testing workflow simulation...")
@@ -183,6 +196,8 @@ def test_workflow_simulation():
         return False
 
 
+@skip_on_ci
+@skip_without_display
 def test_error_handling():
     """Test error handling."""
     print("Testing error handling...")
@@ -216,6 +231,8 @@ def test_error_handling():
         return False
 
 
+@skip_on_ci
+@skip_without_display
 def test_performance():
     """Test system performance."""
     print("Testing performance...")


### PR DESCRIPTION
## Summary
- add environment-based skip decorators to integration tests
- mark integration tests for pytest selection

## Testing
- `CI=true .venv/bin/python -m pytest src/tests/integration -m integration`
- `CI=true .venv/bin/python -m pytest -q` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6895aba153c083319bd2dbca829f47ae