### PR TITLE
Add xdist optional dependency and parallel worker support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-xdist>=3.0.0",
     "black>=23.0.0",
     "isort>=5.0.0",
     "mypy>=1.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
 # Development requirements for Screen Translator v2.0
 
+# Testing
+pytest-xdist>=3.0.0
+
 # Code quality tools
 black>=23.7.0
 isort>=5.12.0

--- a/src/tests/unit/test_build_run_tests.py
+++ b/src/tests/unit/test_build_run_tests.py
@@ -1,0 +1,13 @@
+import pytest
+from unittest.mock import patch
+import subprocess
+import build
+
+
+def test_run_tests_passes_workers_option():
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value.returncode = 0
+        build.run_tests(workers='auto')
+        cmd = mock_run.call_args[0][0]
+    assert '-n' in cmd
+    assert 'auto' in cmd


### PR DESCRIPTION
## Summary
- enable pytest-xdist in dev dependencies and requirements
- allow build.py test command to run tests in parallel via `--workers`
- add unit test covering `run_tests` workers option

## Testing
- `bash dev.sh lint`
- `.venv/bin/pytest -q src/tests/unit/test_build_run_tests.py`
- `.venv/bin/pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract')*
- `.venv/bin/python build.py test --workers auto` *(fails: ModuleNotFoundError: No module named 'pystray')*

------
https://chatgpt.com/codex/tasks/task_e_6895aba0b83c83318ffb8b4ed592683e