### PR TITLE
test: run tests from multiple directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --strict-config --tb=short"
-testpaths = ["src/tests"]
+testpaths = ["src/tests", "tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]


### PR DESCRIPTION
## Summary
- configure pytest to include both src/tests and tests directories

## Testing
- `.venv/bin/pytest -q` *(fails: async def functions are not natively supported, module not found errors, etc.)*
- `bash dev.sh lint`


------
https://chatgpt.com/codex/tasks/task_e_6895aba068b0833195d39b422450e59d