### PR TITLE
Include top-level tests in build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -153,7 +153,7 @@ def run_tests(
     elif test_type == "integration":
         cmd.append("src/tests/integration/")
     elif test_type == "all":
-        cmd.append("src/tests/")
+        cmd.extend(["src/tests/", "tests/"])
     else:
         colored_print(f"❌ Unknown test type: {test_type}", Colors.RED)
         return False
@@ -799,7 +799,7 @@ Examples:
                     elif test_type == "integration":
                         cmd.append("src/tests/integration/")
                     elif test_type == "all":
-                        cmd.append("src/tests/")
+                        cmd.extend(["src/tests/", "tests/"])
 
                     if verbose:
                         cmd.append("-v")


### PR DESCRIPTION
## Summary
- run `build.py` tests against both `src/tests/` and top-level `tests/`
- support the same behavior when using virtual environments

## Testing
- `bash dev.sh lint`
- `.venv/bin/python build.py test`

------
https://chatgpt.com/codex/tasks/task_e_6895bbf1dd7c8331b90b4e4839cf783b