### PR TITLE
Handle security scan failures

### DIFF
--- a/build.py
+++ b/build.py
@@ -315,17 +315,20 @@ def run_security_scan() -> bool:
         ([sys.executable, "-m", "bandit", "-r", "src/", "-f", "json"], "Bandit security scan"),
         ([sys.executable, "-m", "safety", "check", "--json"], "Safety vulnerability check"),
     ]
-    
+
     all_passed = True
-    
+
     for cmd, name in scans:
         try:
             colored_print(f"  Running {name}...", Colors.CYAN)
-            run_command(cmd, check=False, capture=True)
+            run_command(cmd, check=True, capture=True)
             colored_print(f"  ✅ {name} completed", Colors.GREEN)
+        except subprocess.CalledProcessError:
+            all_passed = False
+            colored_print(f"  ❌ {name} found issues", Colors.RED)
         except FileNotFoundError:
             colored_print(f"  ⚠️ {name} skipped (tool not installed)", Colors.YELLOW)
-    
+
     return all_passed
 
 def clean_project() -> None:

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -1,0 +1,19 @@
+import unittest
+from pathlib import Path
+
+from build import run_security_scan
+
+
+class SecurityScanTest(unittest.TestCase):
+    """Tests for the run_security_scan helper."""
+
+    def test_bandit_violation_causes_failure(self):
+        """run_security_scan should return False when Bandit finds issues."""
+        vuln_file = Path("src") / "vuln_example.py"
+        vuln_file.write_text("def bad():\n    eval('1+1')\n")
+        try:
+            result = run_security_scan()
+            self.assertFalse(result)
+        finally:
+            if vuln_file.exists():
+                vuln_file.unlink()


### PR DESCRIPTION
## Summary
- Ensure run_security_scan propagates failures from Bandit and Safety
- Add regression test verifying Bandit violations cause scan failure

## Testing
- `.venv/bin/python -m pytest tests/test_security_scan.py -q`
- `.venv/bin/python -m pytest -q --maxfail=1` *(fails: TestTranslationUseCaseIntegration::test_translate_text_cache_miss_flow)*
- `bash dev.sh lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bbf418bc83318438cd5e5ee5c512